### PR TITLE
Fix: Add New should handle Mac/UNIX paths

### DIFF
--- a/Editor/SettingsRegister.cs
+++ b/Editor/SettingsRegister.cs
@@ -263,7 +263,7 @@ namespace lisandroct.EventSystem
                 .Select(a => a.Replace('/', '\\').Split('\\').Last());
 
             return AppDomain.CurrentDomain.GetAssemblies()
-                .Where(assembly => assembly.IsDynamic || assemblies.Contains(assembly.Location.Split('\\').Last()))
+                .Where(assembly => assembly.IsDynamic || assemblies.Contains(assembly.Location.Replace('/', '\\').Split('\\').Last()))
                 .SelectMany(assembly => assembly.GetTypes())
                 .Where(IsNotGeneric)
                 .OrderBy(type => type.Namespace)


### PR DESCRIPTION
Fixes #2

When `SettingsRegister.LoadTypes()` checks assembly location path, it should handle paths with Mac/UNIX forward-slash separator as well as Windows backslash.