### PR TITLE
Fix: Rename Event<...> to GameEvent<...>

### DIFF
--- a/Editor/EventInspector.cs
+++ b/Editor/EventInspector.cs
@@ -25,7 +25,7 @@ namespace lisandroct.EventSystem
     
     public class EventInspector<T, S> : Editor where S : TestObject<T>
     {
-        private Event<T> Event => target as Event<T>;
+        private GameEvent<T> Event => target as GameEvent<T>;
 
         private S TestObject { get; set; }
         private SerializedObject SerializedTestObject { get; set; }
@@ -63,7 +63,7 @@ namespace lisandroct.EventSystem
     
     public abstract class EventInspector<T, U, S> : Editor where S : TestObject<T, U>
     {
-        private Event<T, U> Event => target as Event<T, U>;
+        private GameEvent<T, U> Event => target as GameEvent<T, U>;
 
         private S TestObject { get; set; }
         private SerializedObject SerializedTestObject { get; set; }
@@ -104,7 +104,7 @@ namespace lisandroct.EventSystem
     
     public abstract class EventInspector<T, U, V, S> : Editor where S : TestObject<T, U, V>
     {
-        private Event<T, U, V> Event => target as Event<T, U, V>;
+        private GameEvent<T, U, V> Event => target as GameEvent<T, U, V>;
 
         private S TestObject { get; set; }
         private SerializedObject SerializedTestObject { get; set; }
@@ -148,7 +148,7 @@ namespace lisandroct.EventSystem
     
     public abstract class EventInspector<T, U, V, W, S> : Editor where S : TestObject<T, U, V, W>
     {
-        private Event<T, U, V, W> Event => target as Event<T, U, V, W>;
+        private GameEvent<T, U, V, W> Event => target as GameEvent<T, U, V, W>;
 
         private S TestObject { get; set; }
         private SerializedObject SerializedTestObject { get; set; }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Event system for Unity using ScriptableObjects based on the concept introduced by Ryan Hipple in his [talk](https://www.youtube.com/watch?v=raQ3iHhE_Kk) at Unite 2017.
 
 ## Why
-Event systems and the observable pattern are very common in games and programs of every kind. They're so common that C# has it's own solution implemented at the language level. Then why do we need yet another system? **Event System** makes the most out of the Unity Editor.
+Event systems and the observable pattern are very common in games and programs of every kind. They're so common that C# has its own solution implemented at the language level. Then why do we need yet another system? **Event System** makes the most out of the Unity Editor.
 
 In **Event System** you can create the events and set all the listeners in the editor without writing any code.
 
@@ -14,7 +14,7 @@ This last point comes with another advantage: using **Event System** it's trivia
 
 **Event System**  also makes it trivial to test events from the inspector while in Play Mode, making development easier and faster.
 
-Implementing events with **Event System** makes easier to keep scenes completely independent from each other. You can have the subject in one scene and the listeners in another scene and subscribing to the event would still be trivial.
+Implementing events with **Event System** makes it easier to keep scenes completely independent from each other. You can have the subject in one scene and the listeners in another scene and subscribing to the event would still be trivial.
 
 Finally, since events are just ScriptableObjects, it's very simple to create them programatically in runtime and use them like any other C# event (since the API is very minimal and similar).
 

--- a/Runtime/GameEvents.cs
+++ b/Runtime/GameEvents.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace lisandroct.EventSystem
 {
-    public abstract class Event<T> : ScriptableObject
+    public abstract class GameEvent<T> : ScriptableObject
     {
         private event Action<T> OnEvent;
         public int HandlersCount => OnEvent?.GetInvocationList().Length ?? 0;
@@ -21,7 +21,7 @@ namespace lisandroct.EventSystem
         public void Unregister(Action<T> handler) => OnEvent -= handler;
     }
 
-    public abstract class Event<T, U> : ScriptableObject
+    public abstract class GameEvent<T, U> : ScriptableObject
     {
         private event Action<T, U> OnEvent;
         public int HandlersCount => OnEvent?.GetInvocationList().Length ?? 0;
@@ -39,7 +39,7 @@ namespace lisandroct.EventSystem
         public void Unregister(Action<T, U> listener) => OnEvent -= listener;
 }
 
-    public abstract class Event<T, U, V> : ScriptableObject
+    public abstract class GameEvent<T, U, V> : ScriptableObject
     {
         private event Action<T, U, V> OnEvent;
         public int HandlersCount => OnEvent?.GetInvocationList().Length ?? 0;
@@ -57,7 +57,7 @@ namespace lisandroct.EventSystem
         public void Unregister(Action<T, U, V> listener) => OnEvent -= listener;
     }
 
-    public abstract class Event<T, U, V, W> : ScriptableObject
+    public abstract class GameEvent<T, U, V, W> : ScriptableObject
     {
         private event Action<T, U, V, W> OnEvent;
         public int HandlersCount => OnEvent?.GetInvocationList().Length ?? 0;

--- a/Runtime/GameEvents.cs.meta
+++ b/Runtime/GameEvents.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 011c8ed341ab64a44978da56d8147c29
+guid: a2437962c699a4c4a878ec93e938de08
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Listeners.cs
+++ b/Runtime/Listeners.cs
@@ -12,8 +12,8 @@ namespace lisandroct.EventSystem
     public abstract class Listener<T> : MonoBehaviour, IListener<T> 
     {
         [SerializeField]
-        private Event<T> _event;
-        private Event<T> Event => _event;
+        private GameEvent<T> _event;
+        private GameEvent<T> Event => _event;
 
         [SerializeField]
         private UnityEvent<T> _response;
@@ -39,8 +39,8 @@ namespace lisandroct.EventSystem
     public abstract class Listener<T0, T1> : MonoBehaviour, IListener<T0, T1>
     {
         [SerializeField]
-        private Event<T0, T1> _event;
-        private Event<T0, T1> Event => _event;
+        private GameEvent<T0, T1> _event;
+        private GameEvent<T0, T1> Event => _event;
 
         [SerializeField]
         private UnityEvent<T0, T1> _response;
@@ -66,8 +66,8 @@ namespace lisandroct.EventSystem
     public abstract class Listener<T0, T1, T2> : MonoBehaviour, IListener<T0, T1, T2>
     {
         [SerializeField]
-        private Event<T0, T1, T2> _event;
-        private Event<T0, T1, T2> Event => _event;
+        private GameEvent<T0, T1, T2> _event;
+        private GameEvent<T0, T1, T2> Event => _event;
 
         [SerializeField]
         private UnityEvent<T0, T1, T2> _response;
@@ -93,8 +93,8 @@ namespace lisandroct.EventSystem
     public abstract class Listener<T0, T1, T2, T3> : MonoBehaviour, IListener<T0, T1, T2, T3>
     {
         [SerializeField]
-        private Event<T0, T1, T2, T3> _event;
-        private Event<T0, T1, T2, T3> Event => _event;
+        private GameEvent<T0, T1, T2, T3> _event;
+        private GameEvent<T0, T1, T2, T3> Event => _event;
 
         [SerializeField]
         private UnityEvent<T0, T1, T2, T3> _response;
@@ -117,7 +117,7 @@ namespace lisandroct.EventSystem
         public void OnEventRaised(T0 arg0, T1 arg1, T2 arg2, T3 arg3) => Response?.Invoke(arg0, arg1, arg2, arg3);
     }
     #else
-    public abstract class Listener<T, E, R> : MonoBehaviour, IListener<T> where E : Event<T> where R : UnityEvent<T>
+    public abstract class Listener<T, E, R> : MonoBehaviour, IListener<T> where E : GameEvent<T> where R : UnityEvent<T>
     {
         [SerializeField]
         private E _event;
@@ -144,7 +144,7 @@ namespace lisandroct.EventSystem
         public void OnEventRaised(T arg) => response?.Invoke(arg);
     }
 
-    public abstract class Listener<T0, T1, E, R> : MonoBehaviour, IListener<T0, T1> where E : Event<T0, T1> where R : UnityEvent<T0, T1>
+    public abstract class Listener<T0, T1, E, R> : MonoBehaviour, IListener<T0, T1> where E : GameEvent<T0, T1> where R : UnityEvent<T0, T1>
     {
         [SerializeField]
         private E _event;
@@ -171,7 +171,7 @@ namespace lisandroct.EventSystem
         public void OnEventRaised(T0 arg0, T1 arg1) => Response?.Invoke(arg0, arg1);
     }
 
-    public abstract class Listener<T0, T1, T2, E, R> : MonoBehaviour, IListener<T0, T1, T2> where E : Event<T0, T1, T2> where R : UnityEvent<T0, T1, T2>
+    public abstract class Listener<T0, T1, T2, E, R> : MonoBehaviour, IListener<T0, T1, T2> where E : GameEvent<T0, T1, T2> where R : UnityEvent<T0, T1, T2>
     {
         [SerializeField]
         private E _event;
@@ -198,7 +198,7 @@ namespace lisandroct.EventSystem
         public void OnEventRaised(T0 arg0, T1 arg1, T2 arg2) => Response?.Invoke(arg0, arg1, arg2);
     }
 
-    public abstract class Listener<T0, T1, T2, T3, E, R> : MonoBehaviour, IListener<T0, T1, T2, T3> where E : Event<T0, T1, T2, T3> where R : UnityEvent<T0, T1, T2, T3>
+    public abstract class Listener<T0, T1, T2, T3, E, R> : MonoBehaviour, IListener<T0, T1, T2, T3> where E : GameEvent<T0, T1, T2, T3> where R : UnityEvent<T0, T1, T2, T3>
     {
         [SerializeField]
         private E _event;

--- a/Samples~/Example/Scripts/EventSystem/Events/BoolEvent.cs
+++ b/Samples~/Example/Scripts/EventSystem/Events/BoolEvent.cs
@@ -12,6 +12,6 @@ namespace lisandroct.EventSystem.Events {
     
     
     [UnityEngine.CreateAssetMenuAttribute(fileName="OnBoolEvent", menuName="Events/Bool Event")]
-    public class BoolEvent : lisandroct.EventSystem.Event<bool> {
+    public class BoolEvent : lisandroct.EventSystem.GameEvent<bool> {
     }
 }

--- a/Samples~/Example/Scripts/EventSystem/Events/ColorEvent.cs
+++ b/Samples~/Example/Scripts/EventSystem/Events/ColorEvent.cs
@@ -12,6 +12,6 @@ namespace lisandroct.EventSystem.Events {
     
     
     [UnityEngine.CreateAssetMenuAttribute(fileName="OnColorEvent", menuName="Events/Color Event")]
-    public class ColorEvent : lisandroct.EventSystem.Event<UnityEngine.Color> {
+    public class ColorEvent : lisandroct.EventSystem.GameEvent<UnityEngine.Color> {
     }
 }

--- a/Tests/Runtime/Event1.cs
+++ b/Tests/Runtime/Event1.cs
@@ -5,7 +5,7 @@ using NSubstitute;
 
 namespace Given_Event1
 {
-    public class Event1 : Event<int> { }
+    public class Event1 : GameEvent<int> { }
     
     public class Given {
         protected Event1 Event { get; private set; }

--- a/Tests/Runtime/Event2.cs
+++ b/Tests/Runtime/Event2.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using lisandroct.EventSystem;
 using NSubstitute;
 
-public class Event2 : Event<int, int> { }
+public class Event2 : GameEvent<int, int> { }
 
 namespace Given_Event2
 {

--- a/Tests/Runtime/Event3.cs
+++ b/Tests/Runtime/Event3.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using lisandroct.EventSystem;
 using NSubstitute;
 
-public class Event3 : Event<int, int, int> { }
+public class Event3 : GameEvent<int, int, int> { }
 
 namespace Given_Event3
 {

--- a/Tests/Runtime/Event4.cs
+++ b/Tests/Runtime/Event4.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using lisandroct.EventSystem;
 using NSubstitute;
 
-public class Event4 : Event<int, int, int, int> { }
+public class Event4 : GameEvent<int, int, int, int> { }
 
 namespace Given_Event4
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.lisandroct.events",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "displayName": "Event System",
   "description": "Event system for Unity using ScriptableObjects.",
   "unity": "2017.1",


### PR DESCRIPTION
Fixes #13

👀 

I have rebased my commits as you prefer this style.

Changes made:
- Rename `Event<...>` to `GameEvent<...>` and rename file `Events.cs` -> `GameEvents.cs`
- Make corresponding changes in `Listeners.cs`, `EventInspector.cs` and tests
- Update `BoolEvent` & `ColorEvent` in sample code
- Update package to 1.5.1
- Tiny typo fixes to README

Once this is merged, I shall submit a fresh repo for fixing warnings that is rebased.